### PR TITLE
Defect/de574 homepage title

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,7 +1,7 @@
 {
   "preset": "airbnb",
   "requireTrailingComma": null,
-  "requireDotNotation": { "allExcept": [ "snake_case" ] },
+  "requireDotNotation": "except_snake_case",
   "safeContextKeyword": "vm",
   "requireCamelCaseOrUpperCaseIdentifiers": null
 }

--- a/app/cms/services/content_siteconfig.service.js
+++ b/app/cms/services/content_siteconfig.service.js
@@ -1,13 +1,22 @@
-(function () {
-    'use strict';
+(function() {
+  'use strict';
 
-    module.exports = ContentSiteConfigService;
+  module.exports = ContentSiteConfigService;
 
-    ContentSiteConfigService.$inject = [];
+  ContentSiteConfigService.$inject = [];
 
-    function ContentSiteConfigService() {
-        var service = {};
-        service.siteconfig = {};
-        return service;
+  function ContentSiteConfigService() {
+    var service = {
+      siteconfig: {},
+      getTitle: getTitle
+    };
+
+    function getTitle() {
+      return _.isEmpty(service.siteconfig.title) ?
+        'Crossroads' :
+        service.siteconfig.title;
     }
+
+    return service;
+  }
 })();

--- a/app/core.run.js
+++ b/app/core.run.js
@@ -79,7 +79,7 @@
     });
 
     function setupMetaData() {
-      var titleSuffix = ' | ' + ContentSiteConfigService.siteconfig.title;
+      var titleSuffix = ' | ' + ContentSiteConfigService.getTitle();
       $rootScope.meta.siteconfig = ContentSiteConfigService.siteconfig;
       if ($rootScope.meta.title.indexOf(titleSuffix, $rootScope.meta.title.length - titleSuffix.length) === -1) {
         $rootScope.meta.title = $rootScope.meta.title + titleSuffix;

--- a/spec/cms/siteConfig.service.spec.js
+++ b/spec/cms/siteConfig.service.spec.js
@@ -1,0 +1,21 @@
+require('../../app/core');
+
+describe('ContentSiteConfigService', function() {
+  var ContentSiteConfigService;
+
+  beforeEach(angular.mock.module('crossroads.core'));
+
+  beforeEach(inject(function(_ContentSiteConfigService_) {
+    ContentSiteConfigService = _ContentSiteConfigService_;
+  }));
+
+  it('should return the title that is set', function() {
+    ContentSiteConfigService.siteconfig.title = 'Test Title';
+    expect(ContentSiteConfigService.getTitle()).toBe('Test Title');
+  });
+
+  it('should return the default title if one is not set', function() {
+    expect(ContentSiteConfigService.getTitle()).toBe('Crossroads');
+  });
+
+});


### PR DESCRIPTION
Added a method to the service to get the title which returns a default of 'Crossroads' if the title was never set