### PR TITLE
DE898 strange character in currency filter

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -71,7 +71,8 @@ module.exports = {
         definePlugin,
         new webpack.optimize.UglifyJsPlugin({
             sourceMap: false,
-            mangle: false
+            mangle: false,
+            output: { ascii_only: true }
         })
     ]
 };


### PR DESCRIPTION
Add option to uglifyjs to force non-ascii characters to be encoded as \uXXXX:
* ascii_only: false – pass true if you want to encode non-ASCII characters as \uXXXX.