### PR TITLE
DE949: Fix redirection for login within giving flow

### DIFF
--- a/app/login/login_controller.js
+++ b/app/login/login_controller.js
@@ -83,7 +83,7 @@
           clearCredentials();
           // If the state name ends with login or register (like 'login' or 'give.one_time_login'),
           // either redirect to specified URL, or redirect to profile if URL is not specified.
-          if (/login$/.test($state.current.name) || /register$/.test($state.current.name)) {
+          if (_.endsWith($state.current.name, 'login') || _.endsWith($state.current.name, 'register')) {
             $timeout(function() {
               if (Session.hasRedirectionInfo()) {
                 var url = Session.exists('redirectUrl');

--- a/app/login/login_controller.js
+++ b/app/login/login_controller.js
@@ -81,7 +81,9 @@
           $scope.processing = false;
           $scope.loginShow = false;
           clearCredentials();
-          if ($state.current.name === 'login' || $state.current.name === 'register') {
+          // If the state name ends with login or register (like 'login' or 'give.one_time_login'),
+          // either redirect to specified URL, or redirect to profile if URL is not specified.
+          if (/login$/.test($state.current.name) || /register$/.test($state.current.name)) {
             $timeout(function() {
               if (Session.hasRedirectionInfo()) {
                 var url = Session.exists('redirectUrl');


### PR DESCRIPTION
* [DE949](https://rally1.rallydev.com/#/27593764268d/detail/defect/49903405373)
* I think this was broken with the recent changes for login redirect
* I've made slight change to the if statement to account for states that aren't called 'login' or 'register', but end with 'login' or 'register'
  * For example, login state during one-time giving flow is called 'give.one_time_login'
  * During recurring giving flow, it is called 'give.recurring_login'